### PR TITLE
[inetutils]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.inetutils?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # inetutils
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# inetutils
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,1 @@
-command_path: '/bin/ping'
+command_relative_path: '/bin/ping'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,1 @@
-command_relative_path: '/bin/ping'
+command_relative_path: 'bin/ping'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_path: '/bin/ping'

--- a/controls/inetutils_exists.rb
+++ b/controls/inetutils_exists.rb
@@ -1,0 +1,17 @@
+title 'Tests to confirm inetutils exists'
+
+plan_name = input('plan_name', value: 'inetutils')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+inetutils_relative_path = input('command_path', value: '/bin/ping')
+inetutils_installation_directory = command("hab pkg path #{plan_ident}")
+inetutils_full_path = inetutils_installation_directory.stdout.strip + "#{inetutils_relative_path}"
+ 
+control 'core-plans-inetutils-exists' do
+  impact 1.0
+  title 'Ensure inetutils exists'
+  desc '
+  '
+   describe file(inetutils_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/inetutils_exists.rb
+++ b/controls/inetutils_exists.rb
@@ -2,9 +2,6 @@ title 'Tests to confirm inetutils exists'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'inetutils')
-plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
-command_relative_path = input('command_relative_path', value: '/bin/ping')
-command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
 
 control 'core-plans-inetutils-exists' do
   impact 1.0
@@ -12,11 +9,14 @@ control 'core-plans-inetutils-exists' do
   desc '
   Verify inetutils by ensuring /bin/ping exists'
   
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
 
+  command_relative_path = input('command_relative_path', value: '/bin/ping')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
   describe file(command_full_path) do
     it { should exist }
   end

--- a/controls/inetutils_exists.rb
+++ b/controls/inetutils_exists.rb
@@ -7,7 +7,7 @@ control 'core-plans-inetutils-exists' do
   impact 1.0
   title 'Ensure inetutils exists'
   desc '
-  Verify inetutils by ensuring /bin/ping exists'
+  Verify inetutils by ensuring bin/ping exists'
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
@@ -15,8 +15,8 @@ control 'core-plans-inetutils-exists' do
     its('stdout') { should_not be_empty }
   end
 
-  command_relative_path = input('command_relative_path', value: '/bin/ping')
-  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  command_relative_path = input('command_relative_path', value: 'bin/ping')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
   describe file(command_full_path) do
     it { should exist }
   end

--- a/controls/inetutils_exists.rb
+++ b/controls/inetutils_exists.rb
@@ -13,6 +13,7 @@ control 'core-plans-inetutils-exists' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
 
   command_relative_path = input('command_relative_path', value: 'bin/ping')

--- a/controls/inetutils_exists.rb
+++ b/controls/inetutils_exists.rb
@@ -1,17 +1,23 @@
 title 'Tests to confirm inetutils exists'
 
+plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'inetutils')
-plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
-inetutils_relative_path = input('command_path', value: '/bin/ping')
-inetutils_installation_directory = command("hab pkg path #{plan_ident}")
-inetutils_full_path = inetutils_installation_directory.stdout.strip + "#{inetutils_relative_path}"
- 
+plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+command_relative_path = input('command_relative_path', value: '/bin/ping')
+command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+
 control 'core-plans-inetutils-exists' do
   impact 1.0
   title 'Ensure inetutils exists'
   desc '
-  '
-   describe file(inetutils_full_path) do
+  Verify inetutils by ensuring /bin/ping exists'
+  
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  describe file(command_full_path) do
     it { should exist }
   end
 end

--- a/controls/inetutils_works.rb
+++ b/controls/inetutils_works.rb
@@ -1,24 +1,28 @@
 title 'Tests to confirm inetutils works as expected'
 
+plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'inetutils')
-plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
 
 control 'core-plans-inetutils-works' do
   impact 1.0
   title 'Ensure inetutils works as expected'
   desc '
+  Verify inetutils by ensuring (1) its installation directory exists and (2) that
+  it returns the expected version
   '
-  inetutils_path = command("hab pkg path #{plan_ident}")
-  describe inetutils_path do
+  
+  describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
   
-  inetutils_pkg_ident = ((inetutils_path.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-  describe command("DEBUG=true; hab pkg exec #{inetutils_pkg_ident} ping --version") do
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} ping --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stdout') { should match /ping \(GNU inetutils\) 1.9.4/ }
+    its('stdout') { should match /ping \(GNU inetutils\) #{plan_pkg_version}/ }
     its('stderr') { should be_empty }
   end
 end

--- a/controls/inetutils_works.rb
+++ b/controls/inetutils_works.rb
@@ -16,6 +16,7 @@ control 'core-plans-inetutils-works' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
   
   command_relative_path = input('command_relative_path', value: 'bin/ping')

--- a/controls/inetutils_works.rb
+++ b/controls/inetutils_works.rb
@@ -7,8 +7,9 @@ control 'core-plans-inetutils-works' do
   impact 1.0
   title 'Ensure inetutils works as expected'
   desc '
-  Verify inetutils by ensuring (1) its installation directory exists and (2) that
-  it returns the expected version
+  Verify inetutils by ensuring 
+  (1) its installation directory exists and 
+  (2) that it returns the expected version.
   '
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
@@ -17,9 +18,10 @@ control 'core-plans-inetutils-works' do
     its('stdout') { should_not be_empty }
   end
   
-  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
-  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} ping --version") do
+  command_relative_path = input('command_relative_path', value: 'bin/ping')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  describe command("#{command_full_path} --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /ping \(GNU inetutils\) #{plan_pkg_version}/ }

--- a/controls/inetutils_works.rb
+++ b/controls/inetutils_works.rb
@@ -1,0 +1,24 @@
+title 'Tests to confirm inetutils works as expected'
+
+plan_name = input('plan_name', value: 'inetutils')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+
+control 'core-plans-inetutils-works' do
+  impact 1.0
+  title 'Ensure inetutils works as expected'
+  desc '
+  '
+  inetutils_path = command("hab pkg path #{plan_ident}")
+  describe inetutils_path do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  inetutils_pkg_ident = ((inetutils_path.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  describe command("DEBUG=true; hab pkg exec #{inetutils_pkg_ident} ping --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /ping \(GNU inetutils\) 1.9.4/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/inetutils_works.rb
+++ b/controls/inetutils_works.rb
@@ -2,9 +2,6 @@ title 'Tests to confirm inetutils works as expected'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'inetutils')
-plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
-plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
 
 control 'core-plans-inetutils-works' do
   impact 1.0
@@ -14,11 +11,14 @@ control 'core-plans-inetutils-works' do
   it returns the expected version
   '
   
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
   
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
   describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} ping --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: inetutils
+title: Habitat Core Plan inetutils
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan inetutils
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,76 @@
+pkg_name=inetutils
+pkg_origin=core
+pkg_version=1.9.4
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+Inetutils is a collection of common network programs. It includes: an ftp \
+client and server, a telnet client and server, an rsh client and server, an \
+rlogin client and server, a tftp client and server, and much more...\
+"
+pkg_upstream_url="http://www.gnu.org/software/inetutils/"
+pkg_license=('GPL-3.0-or-later')
+pkg_source="http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.xz"
+pkg_shasum="849d96f136effdef69548a940e3e0ec0624fc0c81265296987986a0dd36ded37"
+pkg_deps=(
+  core/glibc
+  core/libcap
+  core/ncurses
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  core/sed
+  core/grep
+)
+pkg_bin_dirs=(bin)
+
+do_build() {
+  # Configure flag notes:
+  #
+  # * `--disable-logger`: prevents building the `logger`, as the version from
+  #   Util-linux will be used instead
+  # * `--disable-whois`: prevents building the `whois` tool, which is out of
+  #   date
+  # * `--disable-r*`: prevents building of obsolete programs such as `rlogin`,
+  #   `rsh`, etc.
+  # * `--disable-servers`: prevents the building of the server components in
+  #   this codebase, such as `telnetd`, `ftpd`, etc.--a dedicated Plan for
+  #   any of these service components is much preferred
+  ./configure \
+    --prefix="$pkg_prefix" \
+    --disable-logger \
+    --disable-whois \
+    --disable-rcp \
+    --disable-rexec \
+    --disable-rlogin \
+    --disable-rsh \
+    --disable-servers
+  make
+}
+
+do_install() {
+  do_default_install
+
+  # `libexec/` directory is not used
+  rm -rfv "$pkg_prefix/libexec"
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/coreutils
+    core/sed
+    core/grep
+  )
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,10 @@
+# All commands provided require known state that will differ based on the host
+# it's run on (hostname) or external connectivity. While we could exercise the
+# latter, it's likely to lead to a number of false failures depending on
+# the network it's run from, and the status of the target host.
+
+# For now, we'll exercise the command with --usage to ensure it's runnable .
+@test "can run ping --usage" {
+  run hab pkg exec $TEST_PKG_IDENT ping --usage
+  [ "$status" -eq 0 ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install core/iana-etc
+hab pkg install "${TEST_PKG_IDENT}"
+
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
### Outstanding tasks:
- [x] remove DEBUG
- [x] use full path to binary instead of hab pkg exec
- [x] parsing the pkg_version from the installation path.

```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://2236becf633bd011dbc2f6ae8da4329949422778644669d9da5d92beb10aeace --input-file /src/attributes.yml

Profile: Habitat Core Plan inetutils (inetutils)
Version: 0.1.0
Target:  docker://2236becf633bd011dbc2f6ae8da4329949422778644669d9da5d92beb10aeace

  ✔  core-plans-inetutils-works: Ensure inetutils works as expected
     ✔  Command: `hab pkg path core/inetutils` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/inetutils` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/inetutils/1.9.4/20200603164509 ping --version` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/inetutils/1.9.4/20200603164509 ping --version` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/inetutils/1.9.4/20200603164509 ping --version` stdout is expected to match /ping \(GNU inetutils\) 1.9.4/
     ✔  Command: `DEBUG=true; hab pkg exec core/inetutils/1.9.4/20200603164509 ping --version` stderr is expected to be empty
  ✔  core-plans-inetutils-exists: Ensure inetutils exists
     ✔  File /hab/pkgs/core/inetutils/1.9.4/20200603164509/bin/ping is expected to exist


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 7 successful, 0 failures, 0 skipped
+ set +x
[11][default:/src:0]# 
```