### PR TITLE
pass copy-dt-needed-entries on to make to pick up correct symbols

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -48,7 +48,7 @@ do_build() {
     --disable-rlogin \
     --disable-rsh \
     --disable-servers
-  make
+  make LDFLAGS="$LDFLAGS -Wl,--copy-dt-needed-entries"
 }
 
 do_install() {


### PR DESCRIPTION
This fixes building against refreshed packages. The clue to include this was discovered thanks to https://stackoverflow.com/questions/19901934/libpthread-so-0-error-adding-symbols-dso-missing-from-command-line/55086637#55086637

Signed-off-by: Matt Wrock <matt@mattwrock.com>